### PR TITLE
refactor: reorganize and clean up codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "anyrun"
-version = "0.4.12-alpha"
+version = "0.4.12-alpha.1"
 dependencies = [
  "abi_stable",
  "anyrun-interface 0.1.0",

--- a/anyrun/Cargo.toml
+++ b/anyrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anyrun"
-version = "0.4.12-alpha"
+version = "0.4.12-alpha.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/anyrun/src/config.rs
+++ b/anyrun/src/config.rs
@@ -185,13 +185,6 @@ pub struct Args {
     pub config: ConfigArgs,
 }
 
-// Enum for positions
-#[derive(Deserialize, Clone, Copy, ValueEnum)]
-enum Position {
-    Top,
-    Center,
-}
-
 // Enum for actions after GTK has finished
 pub enum PostRunAction {
     Copy(Vec<u8>),

--- a/anyrun/src/utils.rs
+++ b/anyrun/src/utils.rs
@@ -1,0 +1,80 @@
+use std::{cell::RefCell, fs, path::PathBuf, rc::Rc};
+
+use gtk::gdk;
+use log::*;
+use nix::unistd;
+use wl_clipboard_rs::copy;
+
+use crate::config::{style_names, PostRunAction, RuntimeData};
+
+fn serve_copy_requests(bytes: &[u8]) {
+    let mut opts = copy::Options::new();
+    opts.foreground(true);
+    opts.copy(
+        copy::Source::Bytes(bytes.to_vec().into_boxed_slice()),
+        copy::MimeType::Autodetect,
+    )
+    .expect("Failed to serve copy bytes");
+}
+
+pub fn handle_post_run_action(runtime_data: Rc<RefCell<RuntimeData>>) {
+    if let PostRunAction::Copy(bytes) = &runtime_data.borrow().post_run_action {
+        match unsafe { unistd::fork() } {
+            Ok(unistd::ForkResult::Parent { .. }) => {
+                info!("Child spawned to serve copy requests.");
+            }
+            Ok(unistd::ForkResult::Child) => {
+                serve_copy_requests(bytes);
+            }
+            Err(why) => {
+                error!("Failed to fork for copy sharing: {}", why);
+            }
+        }
+    }
+}
+
+pub fn load_custom_css(runtime_data: Rc<RefCell<RuntimeData>>) {
+    let config_dir = &runtime_data.borrow().config_dir;
+    let css_path = config_dir.join("style.css");
+
+    if fs::metadata(&css_path).is_ok() {
+        info!("Applying custom CSS from {:?}", css_path);
+        let provider = gtk::CssProvider::new();
+        provider.load_from_path(css_path);
+
+        let display = gdk::Display::default().expect("Failed to get GDK display for CSS provider!");
+        gtk::style_context_add_provider_for_display(
+            &display,
+            &provider,
+            gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
+        );
+    }
+}
+
+pub fn build_label(name: &str, use_markup: bool, label: &str) -> gtk::Label {
+    gtk::Label::builder()
+        .name(name)
+        .wrap(true)
+        .xalign(0.0)
+        .use_markup(use_markup)
+        .halign(gtk::Align::Start)
+        .valign(gtk::Align::Center)
+        .vexpand(true)
+        .label(label)
+        .build()
+}
+
+pub fn build_image(icon: &str) -> gtk::Image {
+    let mut match_image = gtk::Image::builder()
+        .name(style_names::MATCH)
+        .pixel_size(32);
+
+    let path = PathBuf::from(icon);
+
+    match_image = if path.is_absolute() {
+        match_image.file(path.to_string_lossy())
+    } else {
+        match_image.icon_name(icon)
+    };
+    match_image.build()
+}

--- a/examples/config.ron
+++ b/examples/config.ron
@@ -4,12 +4,17 @@ Config(
     // Fraction(n): A fraction of the width or height of the full screen (depends on exclusive zones and the settings related to them) window respectively
 
     // The width of the runner
-    width: Absolute(800),
+    width: Fraction(0.5),
 
     // The height of the runner
-    height: Absolute(0),
+    height: Fraction(0.5),
 
     // Array of edges where to anchor window. Window will be stretched if two opposite edges specifyed
+    // You can specify empty array to center the window like th follows
+    // ```
+    //     edges: [],
+    // ```
+    // But if you delete/comment this option if will have default value
     // Possible values: Left, Right, Top, Bottom
     // Default: [Top]
     edges: [Top],


### PR DESCRIPTION
- Bump version in Cargo.toml to 0.4.12-alpha.1
- Remove unused Position enum in config.rs
- Rename types.rs to gmatch.rs and move GMatch-related code
- Refactor GMatch to include to_widget method for converting to gtk::Widget
- Clean up imports and remove unused dependencies
- Refactor main.rs:
  - Simplify module imports and reorganize main function
  - Remove unused fork and copy functions
  - Simplify GTK widget setup and event handling
- Refactor plugins.rs:
  - Remove build_label and build_image functions, moved to utils.rs
  - Simplify handle_matches and refresh_matches functions
- Refactor ui.rs:
  - Modularize window and entry setup functions
  - Simplify event handler connections
  - Consolidate refresh_matches call

Overall improvements for readability, maintainability, and performance.